### PR TITLE
#72 Added default language definition to user table migration

### DIFF
--- a/database/migrations/2018_04_28_201131_add_language_to_user_table.php
+++ b/database/migrations/2018_04_28_201131_add_language_to_user_table.php
@@ -14,7 +14,7 @@ class AddLanguageToUserTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('language');
+            $table->string('language')->default('no');
         });
     }
 
@@ -25,6 +25,8 @@ class AddLanguageToUserTable extends Migration
      */
     public function down()
     {
-        //
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('language');
+        });
     }
 }


### PR DESCRIPTION
This requires that we run migration step once again.
Use commands:
1. php artisan migrate:rollback --step=1
2. php artisan migrate

This will remove the language column and add it back with default value